### PR TITLE
Solve the issue of join table name and model of join table

### DIFF
--- a/app/Role.php
+++ b/app/Role.php
@@ -20,6 +20,6 @@ class Role extends Model
      */
     public function users()
     {
-        return $this->belongsToMany('App\User','user_roles');
+        return $this->belongsToMany('App\User');
     }
 }

--- a/app/RoleUser.php
+++ b/app/RoleUser.php
@@ -2,9 +2,9 @@
 
 namespace App;
 
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 
-class UserRole extends Model
+class RoleUser extends Pivot
 {
     public function role()
     {
@@ -15,9 +15,3 @@ class UserRole extends Model
         return $this->belongsTo('App\User');
     }
 }
-
-
-
-
-
-

--- a/app/User.php
+++ b/app/User.php
@@ -40,7 +40,7 @@ class User extends Authenticatable
      */
     public function roles()
     {
-        return $this->belongsToMany('App\Role','user_roles');
+        return $this->belongsToMany('App\Role');
     }
     public function address()
     {

--- a/database/factories/RoleUserFactory.php
+++ b/database/factories/RoleUserFactory.php
@@ -3,7 +3,7 @@
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 use App\Role;
 use App\User;
-use App\UserRole;
+use App\RoleUser;
 use Faker\Generator as Faker;
 use Illuminate\Support\Str;
 /*
@@ -16,7 +16,7 @@ use Illuminate\Support\Str;
 | model instances for testing / seeding your application's database.
 |
 */
-$factory->define(UserRole::class, function (Faker $faker) {
+$factory->define(RoleUser::class, function (Faker $faker) {
     return [
         'user_id' => function(){
          return factory(User::class)->create()->id;

--- a/database/migrations/2020_10_27_215729_create_role_user_table.php
+++ b/database/migrations/2020_10_27_215729_create_role_user_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateUserRolesTable extends Migration
+class CreateRoleUserTable extends Migration
 {
     /**
      * Run the migrations.
@@ -13,7 +13,7 @@ class CreateUserRolesTable extends Migration
      */
     public function up()
     {
-        Schema::create('user_roles', function (Blueprint $table) {
+        Schema::create('role_user', function (Blueprint $table) {
             $table->id();
             $table->integer('role_id');
             $table->integer('user_id');
@@ -28,6 +28,6 @@ class CreateUserRolesTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('user_roles');
+        Schema::dropIfExists('role_user');
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,8 +21,8 @@
         <server name="APP_ENV" value="testing"/>
         <server name="BCRYPT_ROUNDS" value="4"/>
         <server name="CACHE_DRIVER" value="array"/>
-        <!-- <server name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <server name="DB_DATABASE" value=":memory:"/> -->
+        <server name="DB_CONNECTION" value="pgsql"/>
+        <server name="DB_DATABASE" value="ladder_app"/>
         <server name="MAIL_MAILER" value="array"/>
         <server name="QUEUE_CONNECTION" value="sync"/>
         <server name="SESSION_DRIVER" value="array"/>

--- a/tests/Unit/RoleUserTest.php
+++ b/tests/Unit/RoleUserTest.php
@@ -5,15 +5,15 @@ namespace Tests\Unit;
 use Tests\TestCase;
 use App\User;
 use App\Role;
-use App\UserRole;
+use App\RoleUser;
 
-class UserRoleTest extends TestCase
+class RoleUserTest extends TestCase
 {
     /** @test */
     public function user_role_should_belong_to_user_and_role()
     {
         
-    $userRole = factory(UserRole::class)->create();
+    $userRole = factory(RoleUser::class)->create();
 
     $userRole->user()->associate(factory(User::class)->create());
     $userRole->role()->associate(factory(Role::class)->create());


### PR DESCRIPTION
Renamed join table , test file, factory file and model for this intermediate table name according to laravel naming convention and  did some changes in related model(RoleUser) as many-to-many pivot models should extend the Illuminate\Database\Eloquent\Relations\Pivot class according to laravel documentation.